### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Nat Weerawan<nat.wrw@gmail.com>
 maintainer=Nat Weerawan<nat.wrw@gmail.com>
 sentence= Mqtt wrapper for Chiang Mai Maker Club
 paragraph=
+category=Communication
 url=http://www.cmmakerclub.com
 architectures=esp8266


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library CMMC_MqttWrapper is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
